### PR TITLE
[Fix]admin/users/show.html.erbの紹介文の文字崩れ修正

### DIFF
--- a/app/javascript/stylesheets/admin/a_users.scss
+++ b/app/javascript/stylesheets/admin/a_users.scss
@@ -54,6 +54,10 @@
 .a_profile-show .sec01 .a-profile-item-right {
   font-family: 'Noto Serif JP', serif;
   flex-basis: 66%;
+  width: 68%;
+}
+.a_profile-show .sec01 .a-profile-item-right .a-user-introduction {
+  overflow-wrap: break-word;
 }
 .a-profile-show-action {
   display: flex;

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -21,7 +21,9 @@
     </div>
     <div class="sec01">
       <div class="a-profile-item-left">紹介文</div>
-      <div class="a-profile-item-right"><%= @user.introduction %></div>
+      <div class="a-profile-item-right">
+        <p class="a-user-introduction"><%= @user.introduction %></p>
+      </div>
     </div>
     <div class="sec01">
       <div class="a-profile-item-left">会員ステータス</div>


### PR DESCRIPTION
- admin/users/show.html.erbのユーザ紹介文の文章が長文の場合、自動で改行されずレイアウトが崩れてしまっていたため、修正